### PR TITLE
Fix parameter error

### DIFF
--- a/API.json
+++ b/API.json
@@ -2605,7 +2605,7 @@
         "summary" : "Benchmark report.",
         "produces" : [ "application/json" ],
         "parameters" : [ {
-          "name" : "?type=",
+          "name" : "type",
           "in" : "query",
           "required" : false,
           "type" : "string",


### PR DESCRIPTION
It imports now with warnings only.

Unable to create documentation part: [Model name must be alphanumeric: Customer.Notes (placeholder)]. Ignoring.
Unable to create documentation part: [Model name must be alphanumeric: CustomerProfile.Notes (placeholder)]. Ignoring.
Unsupported model type 'IntegerProperty' in 200 response to method 'GET /accounts/{account}/safetospend'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /api/key'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /api/ratelimit'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /api/whoami'. Ignoring.
Unsupported model type 'IntegerProperty' in 200 response to method 'GET /currency/convert/{base}/{currency}/{amount}'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /currency/list/{base}'. Ignoring.
Unsupported model type 'ArrayModel' in request schema for 'POST /insurance/car/{licensenumber}'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /insurance/weatheralert/{latitude}/{longditude}'. Ignoring.
Unsupported model type 'ArrayModel' in request schema for 'POST /loans/apply'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /location/atm/{latitude}/{longditude}'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /location/branch/details/{branchid}'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /reports/transactions/{year}/{month}/{customerId}'. Ignoring.
Unsupported model type 'DecimalProperty' in 200 response to method 'GET /stocks/price/{ticker}/{timestamp}'. Ignoring.
Unsupported model type 'ArrayModel' in request schema for 'POST /vipps/customer'. Ignoring.
Unsupported model type 'ArrayModel' in request schema for 'POST /vipps/settlement/create'. Ignoring.
Unsupported model type 'StringProperty' in 200 response to method 'GET /vipps/settlement/{settlementid}'. Ignoring.
Unsupported model type 'ArrayModel' in request schema for 'POST /vipps/settlement/{settlementid}/expense'. Ignoring.